### PR TITLE
fix(gate-m2): prevent bash arithmetic syntax error in mock density check

### DIFF
--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -185,20 +185,29 @@ else
   for test_file in $ALL_PUSHED_TEST_FILES; do
     if [ -f "$test_file" ]; then
       # Count mock keyword references (precise patterns only)
+      # Use grep -o piped to wc -l for reliable single-number output (grep -c can emit
+      # multi-line output with filenames under some grep versions, causing bash arithmetic
+      # syntax errors). grep -o extracts each match on its own line, wc -l counts them.
       MOCK_COUNT=0
       for kw in 'jest\.mock' 'vi\.mock' 'jest\.spyOn' 'vi\.spyOn' 'jest\.fn' 'vi\.fn' \
                 'mockResolvedValue' 'mockRejectedValue' 'mockReturnValue' 'mockImplementation' \
                 'createMock' 'mockReset' 'mockClear' 'mockRestore' 'MagicMock' 'unittest\.mock' \
-                '\.patch(' 'gomock' 'mockgen' '.EXPECT()'; do
-        c=$(grep -o -c "$kw" "$test_file" 2>/dev/null || echo "0")
+                '\.patch(' 'gomock' 'mockgen' '\.EXPECT()'; do
+        c=$(grep -o "$kw" "$test_file" 2>/dev/null | wc -l || echo "0")
+        # Guard against empty/non-numeric values that break bash arithmetic
+        c=${c//[^0-9]/}
+        c=${c:-0}
         MOCK_COUNT=$((MOCK_COUNT + c))
       done
 
       # Count total non-empty, non-comment lines for density denominator
       TOTAL_LINES=$(grep -v '^\s*$' "$test_file" | grep -v '^\s*//' | grep -v '^\s*\*' | grep -v '^\s*#' | wc -l | awk '{print $1}')
+      TOTAL_LINES=${TOTAL_LINES//[^0-9]/}
+      TOTAL_LINES=${TOTAL_LINES:-0}
 
       if [ "$TOTAL_LINES" -gt 0 ] 2>/dev/null; then
         MOCK_DENSITY=$(awk "BEGIN {printf \"%.1f\", ($MOCK_COUNT / $TOTAL_LINES) * 100}")
+        MOCK_DENSITY=${MOCK_DENSITY:-"0"}
       else
         MOCK_DENSITY="0"
       fi

--- a/src/npm-package/hooks/pre-push
+++ b/src/npm-package/hooks/pre-push
@@ -185,20 +185,29 @@ else
   for test_file in $ALL_PUSHED_TEST_FILES; do
     if [ -f "$test_file" ]; then
       # Count mock keyword references (precise patterns only)
+      # Use grep -o piped to wc -l for reliable single-number output (grep -c can emit
+      # multi-line output with filenames under some grep versions, causing bash arithmetic
+      # syntax errors). grep -o extracts each match on its own line, wc -l counts them.
       MOCK_COUNT=0
       for kw in 'jest\.mock' 'vi\.mock' 'jest\.spyOn' 'vi\.spyOn' 'jest\.fn' 'vi\.fn' \
                 'mockResolvedValue' 'mockRejectedValue' 'mockReturnValue' 'mockImplementation' \
                 'createMock' 'mockReset' 'mockClear' 'mockRestore' 'MagicMock' 'unittest\.mock' \
-                '\.patch(' 'gomock' 'mockgen' '.EXPECT()'; do
-        c=$(grep -o -c "$kw" "$test_file" 2>/dev/null || echo "0")
+                '\.patch(' 'gomock' 'mockgen' '\.EXPECT()'; do
+        c=$(grep -o "$kw" "$test_file" 2>/dev/null | wc -l || echo "0")
+        # Guard against empty/non-numeric values that break bash arithmetic
+        c=${c//[^0-9]/}
+        c=${c:-0}
         MOCK_COUNT=$((MOCK_COUNT + c))
       done
 
       # Count total non-empty, non-comment lines for density denominator
       TOTAL_LINES=$(grep -v '^\s*$' "$test_file" | grep -v '^\s*//' | grep -v '^\s*\*' | grep -v '^\s*#' | wc -l | awk '{print $1}')
+      TOTAL_LINES=${TOTAL_LINES//[^0-9]/}
+      TOTAL_LINES=${TOTAL_LINES:-0}
 
       if [ "$TOTAL_LINES" -gt 0 ] 2>/dev/null; then
         MOCK_DENSITY=$(awk "BEGIN {printf \"%.1f\", ($MOCK_COUNT / $TOTAL_LINES) * 100}")
+        MOCK_DENSITY=${MOCK_DENSITY:-"0"}
       else
         MOCK_DENSITY="0"
       fi


### PR DESCRIPTION
## Problem

The pre-push hook's Gate M2 (Mock Density Check) crashes with a bash arithmetic syntax error on line 194:
```
/home/boyingliu01/.config/xp-gate/hooks/pre-push: line 194: 0
0: syntax error in expression (error token is "0")
```

## Root Cause

`grep -o -c` can emit multi-line output with filenames under certain grep versions (e.g., when matching patterns produce inconsistent output format). The result is fed directly into `$((...))` arithmetic, which cannot parse non-numeric or multi-line values.

Additionally, the keyword `.EXPECT()` (unquoted dot) was treated as a wildcard in grep's default regex mode, matching unexpected text.

## Fix

1. **Replace `grep -o -c` with `grep -o | wc -l`** — reliable single-number output in all grep versions
2. **Fix `.EXPECT()` → `\.EXPECT()`** — properly escape the literal dot
3. **Add numeric sanitization guards** — `c=${c//[^0-9]/}` strips non-numeric chars from grep output
4. **Add `TOTAL_LINES` sanitization** — same guard for the denominator
5. **Guard `MOCK_DENSITY` against empty/unset values**

## Files Changed

- `githooks/pre-push`
- `src/npm-package/hooks/pre-push`

## Testing

- Tested with real test file (RouteService.test.ts): produces correct 4.3% density
- Tested with empty/no-match file: produces 0.0% density
- Tested with DOC_ONLY (md/yaml only) path: correctly skips Gate M2
- `bash -n` syntax check passes on both files