### PR TITLE
fix(mock-policy): resolve 13 Windows path test failures (#133)

### DIFF
--- a/src/mock-policy/__tests__/integration.test.ts
+++ b/src/mock-policy/__tests__/integration.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { tmpdir } from 'os';
 import { readFile } from 'fs/promises';
 import { scanProjectScope } from '../scope-scanner';
@@ -277,7 +277,7 @@ describe('Full pipeline: scanProjectScope → MockDecisionEngine → validateFil
     const testFile = join(tmpDir, testFileRelative);
 
     // Write test file on disk
-    const parentDir = testFile.substring(0, testFile.lastIndexOf('/'));
+    const parentDir = dirname(testFile);
     mkdirSync(parentDir, { recursive: true });
     writeFileSync(testFile, testContent);
 

--- a/src/mock-policy/__tests__/scope-scanner.test.ts
+++ b/src/mock-policy/__tests__/scope-scanner.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { tmpdir } from 'os';
 import {
   simpleGlobMatch,
@@ -163,19 +163,19 @@ describe('isExternalImport', () => {
 describe('resolveToRealPath', () => {
   it('replaces @/ prefix with src/', () => {
     const result = resolveToRealPath('@/components/Button', '/project');
-    expect(result).toBe('/project/src/components/Button');
+    expect(result).toBe(resolve('/project', 'src/components/Button'));
   });
 
   it('preserves paths without @/ alias', () => {
     const result = resolveToRealPath('./foo/bar', '/project');
     // resolve normalizes ./ away
-    expect(result).toBe('/project/foo/bar');
+    expect(result).toBe(resolve('/project', 'foo/bar'));
   });
 
   it('resolves absolute paths correctly', () => {
     const result = resolveToRealPath('/absolute/path', '/project');
     // Absolute paths remain absolute (resolve treats them as-is)
-    expect(result).toBe('/absolute/path');
+    expect(result).toBe(resolve('/absolute/path'));
   });
 });
 
@@ -316,7 +316,8 @@ describe('classifyDependency', () => {
 
   it('uses existCache when provided', () => {
     const cache = new Map<string, boolean>();
-    cache.set('/fake/project/src/foo', true);
+    // Cache key must match the resolved path that classifyDependency computes internally
+    cache.set(resolveToRealPath('@/foo', '/fake/project'), true);
 
     const result = classifyDependency('@/foo', baseScope, {
       ...baseOptions,

--- a/src/mock-policy/gate-m3.ts
+++ b/src/mock-policy/gate-m3.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'fs/promises';
-import { join } from 'path';
+import { isAbsolute, join } from 'path';
 import { loadMockPolicyConfig } from './config';
 import { scanProjectScope } from './scope-scanner';
 import MockDecisionEngine from './mock-decision-engine';
@@ -113,7 +113,7 @@ async function validateFile(
   projectRoot: string,
   severity: 'warning' | 'error',
 ): Promise<MockPolicyViolation[]> {
-  const fullPath = testFile.startsWith('/') ? testFile : join(projectRoot, testFile);
+  const fullPath = isAbsolute(testFile) ? testFile : join(projectRoot, testFile);
   const content = await readFile(fullPath, 'utf-8');
   const layer = detectTestLayer(testFile);
   const imports = collectImports(content);
@@ -150,7 +150,7 @@ export async function runGateM3(
   const allImports: string[] = [];
   for (const testFile of testFiles) {
     try {
-  const fullPath = testFile.startsWith('/') ? testFile : join(projectRoot, testFile);
+      const fullPath = isAbsolute(testFile) ? testFile : join(projectRoot, testFile);
       const content = await readFile(fullPath, 'utf-8');
       allImports.push(...collectImports(content));
     } catch {

--- a/src/mock-policy/scope-scanner.ts
+++ b/src/mock-policy/scope-scanner.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
-import { join, resolve } from 'path';
+import { isAbsolute, join, resolve } from 'path';
 import type { ProjectScope, DependencyScope } from './types';
 
 /**
@@ -105,8 +105,8 @@ export function isExternalImport(importPath: string, options: ScanOptions): bool
     return false;
   }
 
-  // Absolute imports starting with / are internal
-  if (importPath.startsWith('/')) {
+  // Absolute imports (Unix /... or Windows C:\...) are internal
+  if (isAbsolute(importPath)) {
     return false;
   }
 

--- a/src/mutation/detect-ai-test.ts
+++ b/src/mutation/detect-ai-test.ts
@@ -52,13 +52,15 @@ function countTestLines(content: string): number {
 }
 
 export function detectTestLayer(testFilePath: string): TestLayer {
-  if (testFilePath.includes('.e2e.') || testFilePath.includes('/e2e/') || testFilePath.startsWith('e2e/')) {
+  // Normalize separators for cross-platform matching (Windows uses \)
+  const normalized = testFilePath.replace(/\\/g, '/');
+  if (normalized.includes('.e2e.') || normalized.includes('/e2e/') || normalized.startsWith('e2e/')) {
     return 'e2e';
   }
-  if (testFilePath.includes('.integration.') || testFilePath.includes('/integration/') || testFilePath.startsWith('integration/')) {
+  if (normalized.includes('.integration.') || normalized.includes('/integration/') || normalized.startsWith('integration/')) {
     return 'integration';
   }
-  if (testFilePath.includes('/__tests__/') || testFilePath.includes('.test.') || testFilePath.includes('.spec.')) {
+  if (normalized.includes('/__tests__/') || normalized.includes('.test.') || normalized.includes('.spec.')) {
     return 'unit';
   }
   return 'unknown';


### PR DESCRIPTION
## Summary

Fixes #133

13 tests in \src/mock-policy/__tests__/\ failed on Windows due to Unix-style path assumptions.

## Root Causes

| File | Bug | Impact |
|------|-----|--------|
| \scope-scanner.ts\ | \startsWith('/')\ for absolute path detection | Windows absolute paths (\C:\\...\) misclassified as external |
| \gate-m3.ts\ | \startsWith('/')\ in \alidateFile\ + \unGateM3\ | Path doubling: \join(root, absolutePath)\ on Windows |
| \detect-ai-test.ts\ | \includes('/e2e/')\, \includes('/__tests__/')\ with forward slashes only | Windows backslash separators cause layer detection failure |
| \scope-scanner.test.ts\ | Hardcoded Unix expected paths; cache key mismatch | Assertion failures on Windows |
| \integration.test.ts\ | \substring(0, lastIndexOf('/'))\ for parent dir | Returns empty string on Windows → \mkdir('')\ |

## Fixes

- **Source**: Replace \startsWith('/')\ with \path.isAbsolute()\ (scope-scanner.ts, gate-m3.ts)
- **Source**: Normalize \\\\\\ → \/\ before pattern matching in \detectTestLayer\ (detect-ai-test.ts)
- **Tests**: Use \path.resolve()\ for platform-aware assertions (scope-scanner.test.ts)
- **Tests**: Use \path.dirname()\ for parent dir extraction (integration.test.ts)
- **Tests**: Use \esolveToRealPath()\ to compute cache keys (scope-scanner.test.ts)

## Verification

- Before: 13 failed / 737 passed
- After: 0 failed / 750 passed (58 test files, full suite green)